### PR TITLE
Update Altis Dashboard URL

### DIFF
--- a/lib/vantage.js
+++ b/lib/vantage.js
@@ -23,8 +23,8 @@ const REGIONS = [
 ];
 const STACK_CACHE_LIFETIME = 24 * 60 * 60 * 1000;
 
-const AUTH_ENDPOINT = 'https://eu-west-1.aws.hmn.md/wp-login.php?action=oauth2_authorize';
-const BASE_URL = process.env.VANTAGE_URL || 'https://eu-west-1.aws.hmn.md/api/';
+const AUTH_ENDPOINT = 'https://dashboard.altis-dxp.com/wp-login.php?action=oauth2_authorize';
+const BASE_URL = process.env.VANTAGE_URL || 'https://dashboard.altis-dxp.com/api/';
 const TOKEN_ENDPOINT = `${ BASE_URL }oauth2/access_token`;
 const OAUTH_KEY = 'za6qrd2teuev';
 const OAUTH_SECRET = 'kZCn1dluko2lout6gnDqsGqhYn9a7ICFX8YdOhBSd8hhD1w3';


### PR DESCRIPTION
We have migrated from eu-west-1.aws.hmn.md to dashboard.altis-dxp.com. There's a redirect, but it's better to go direct.