### PR TITLE
Update npm install command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @humanmade/altis-cli
+# altis-cli
 
 CLI for running Altis utilities and commands.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You need Node v18 or later.
 
 ```sh
 # Install globally:
-npm install -g @humanmade/altis-cli
+npm install -g altis-cli
 
 # Run it:
 altis-cli

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ npm install -g altis-cli
 
 # Run it:
 altis-cli
+
+# Run with npx:
+npx altis-cli
 ```
 
 ## Available Commands


### PR DESCRIPTION
- This updates the npm install command to remove the outdated `@humanmade/` prefix in the README.
- This adds a command to run `altis-cli` with `npx` in the README.