### PR TITLE
Detect missing file

### DIFF
--- a/lib/commands/stack/scp.js
+++ b/lib/commands/stack/scp.js
@@ -316,7 +316,7 @@ class Connection {
 					`echo -n \$'\\e${ HEADER_INDICATOR };'`,
 
 					// Get size using stat.
-					`stat -c "size=%s" ${ srcPath } | tr -d '\n'`,
+					`stat -c 'size=%s' ${ srcPath } | tr -d '\\n'`,
 
 					// End header, start file.
 					"echo -n $'\\a'",

--- a/lib/commands/stack/scp.js
+++ b/lib/commands/stack/scp.js
@@ -309,6 +309,9 @@ class Connection {
 
 				// Begin transfer.
 				const commands = [
+					// Fail on error or pipe failure.
+					'set -eo pipefail',
+
 					// Start the header.
 					`echo -n \$'\\e${ HEADER_INDICATOR };'`,
 
@@ -326,6 +329,17 @@ class Connection {
 				];
 				this.log( LEVELS.INFO, 'Sending commands' );
 				this.log( LEVELS.DEBUG, JSON.stringify( commands.join( '; ' ) ) );
+				this.session.on( 'disconnect', () => {
+					if ( ! didStartFile ) {
+						// Some sort of error occurred, likely during stat.
+						// Ensure we're closed.
+						status.clear();
+
+						// Pass feedback directly to user.
+						this.log( LEVELS.INFO, 'Did not start file' );
+						reject( new Error( header.substring( 1 ).trimEnd() ) );
+					}
+				} );
 				this.session.write( commands.join( '; ' ) + '\n' );
 			}, 1000 );
 		} );


### PR DESCRIPTION
Ensures the scp command fails if the source file is specified incorrectly.

cc @roborourke 