### PR TITLE
Support resizing terminal

### DIFF
--- a/lib/commands/stack/ssh.js
+++ b/lib/commands/stack/ssh.js
@@ -12,6 +12,8 @@ const INITIAL_SIZE_WAIT = 700;
 
 function connect( data ) {
 	let idleTimer;
+	let terminalResizeListener;
+	let terminalResizeDebounce;
 	let lastWasNewline = true;
 	let startedSshControl = false;
 	const session = new AWSSSMSession( data.stream_url, data.aws_ssm_session_id, data.token );
@@ -25,6 +27,19 @@ function connect( data ) {
 			if ( process.stdin.isTTY ) {
 				process.stdin.setRawMode( true );
 			}
+
+			terminalResizeListener = () => {
+				if ( terminalResizeDebounce ) {
+					clearTimeout( terminalResizeDebounce );
+				}
+
+				terminalResizeDebounce = setTimeout( () => {
+					session.setSize( process.stdout.columns, process.stdout.rows );
+				}, 500 );
+			}
+
+			process.stdout.on( 'resize', terminalResizeListener );
+
 			setTimeout( () => {
 				process.stdin.on( 'data', data => {
 					let msg = '';
@@ -104,6 +119,9 @@ function connect( data ) {
 		}, IDLE_INTERVAL );
 	} );
 	session.on( 'disconnect', ( reason ) => {
+		if ( terminalResizeListener ) {
+			process.stdout.removeListener( 'resize', terminalResizeListener );
+		}
 		if ( idleTimer ) {
 			clearInterval( idleTimer );
 		}


### PR DESCRIPTION
Simple enough, use a debounce to prevent a lot of events when dragging to resize.
