### PR TITLE
Add import-database command

### DIFF
--- a/lib/commands/stack/backup.js
+++ b/lib/commands/stack/backup.js
@@ -35,6 +35,7 @@ const handler = function ( argv ) {
 
 	getStack( argv ).then( stack => {
 		const v = new Vantage( config );
+		v.debug = debug;
 		if ( argv.resume ) {
 			streamLog( v, stack, argv.resume, debug );
 			return;

--- a/lib/commands/stack/deploy.js
+++ b/lib/commands/stack/deploy.js
@@ -43,6 +43,7 @@ const handler = argv => {
 
 	getStack( argv ).then( ( stack ) => {
 		const v = new Vantage( config );
+		v.debug = debug;
 
 		const status = new ora( `Loading builds for ${ stack }…` );
 		status.start();

--- a/lib/commands/stack/import-database.js
+++ b/lib/commands/stack/import-database.js
@@ -1,0 +1,160 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { format, parse } from 'url';
+import { getStack, streamLog } from './util.js';
+import Vantage from '../../vantage.js';
+
+function startImport( vantage, stack, args ) {
+	console.log( `Importing database into ${ stack } from ${ args.from_application }...` );
+
+	const urlBits = parse( `stack/applications/${ stack }/import-database`, true );
+
+	urlBits.query = Object.assign(
+		{},
+		{
+			stream: 'true',
+			from_application: args.from_application,
+			use_mydumper: args.use_mydumper ? '1' : '0',
+		}
+	);
+
+	if ( args.tables ) {
+		args.tables.forEach( ( table, i ) => {
+			urlBits.query[ `tables[${ i }]` ] = table;
+		} );
+	}
+
+	if ( args.replacements ) {
+		Object.entries( args.replacements ).forEach( ( [ search, replace ] ) => {
+			urlBits.query[ `replacements[${ search }]` ] = replace;
+		} );
+	}
+
+	const url = format( urlBits );
+
+	const opts = { method: 'POST' };
+	return vantage.fetch( url, opts ).then( resp => {
+		return resp.text().then( text => {
+			if ( ! resp.ok ) {
+				throw new Error( text );
+			}
+
+			return text;
+		} );
+	} );
+}
+
+const handler = function ( argv ) {
+	const { config, debug } = argv;
+
+	getStack( argv ).then( stack => {
+		const v = new Vantage( config );
+		v.debug = debug;
+
+		if ( argv.resume ) {
+			streamLog( v, stack, argv.resume, debug );
+			return;
+		}
+
+		if ( ! argv.from ) {
+			console.error( chalk.red( 'Error: --from is required (source application to import from)' ) );
+			process.exit( 1 );
+		}
+
+		// Fetch target app info for production safety check.
+		v.fetch( `stack/applications/${ stack }` )
+			.then( resp => resp.json() )
+			.then( data => {
+				if ( data['environment-type'] === 'production' ) {
+					console.log( chalk.red.bold( `\n  WARNING: You are importing a database into a PRODUCTION application (${ stack })` ) );
+					console.log( chalk.red( '  This will overwrite the production database. This action cannot be undone.\n' ) );
+
+					return inquirer.prompt( {
+						type: 'confirm',
+						name: 'confirm',
+						message: 'Are you sure you want to continue?',
+						default: false,
+					} ).then( answers => {
+						if ( ! answers.confirm ) {
+							console.log( 'Aborted.' );
+							process.exit( 0 );
+						}
+					} );
+				}
+			} )
+			.then( () => {
+				// Build args.
+				const args = {
+					from_application: argv.from,
+					use_mydumper: ! argv.mysqldump,
+				};
+
+				// Parse replacements: "search1=replace1,search2=replace2"
+				if ( argv.replacements ) {
+					const replacements = {};
+					argv.replacements.split( ',' ).forEach( pair => {
+						const eqIndex = pair.indexOf( '=' );
+						if ( eqIndex === -1 ) {
+							console.error( chalk.red( `Invalid replacement pair: ${ pair }` ) );
+							console.error( chalk.red( 'Expected format: search=replace' ) );
+							process.exit( 1 );
+						}
+						const search = pair.substring( 0, eqIndex );
+						const replace = pair.substring( eqIndex + 1 );
+						replacements[ search ] = replace;
+					} );
+					args.replacements = replacements;
+				}
+
+				if ( argv.tables ) {
+					args.tables = argv.tables.split( ',' );
+				}
+
+				return startImport( v, stack, args );
+			} )
+			.then( id => {
+				console.log( chalk.yellow( `Import started, resume later with...` ) );
+				console.log( chalk.yellow( `  altis-cli stack import-database ${ stack } --resume ${ id }\n` ) );
+				streamLog( v, stack, id, debug );
+			} )
+			.catch( err => {
+				console.error( chalk.red( `Error: ${ err.message }` ) );
+				process.exit( 1 );
+			} );
+	} );
+};
+
+export default {
+	command: 'import-database [stack]',
+	description: 'Import a database from another application.',
+	builder: subcommand => {
+		subcommand.option( 'from', {
+			description: 'Source application to import the database from.',
+			type: 'string',
+			demandOption: true,
+		} );
+		subcommand.option( 'replacements', {
+			description: 'Comma-separated search=replace pairs for URL replacements.\n(e.g. https://old.com=https://new.com,https://old2.com=https://new2.com)',
+			type: 'string',
+		} );
+		subcommand.option( 'tables', {
+			description: 'Comma-separated list of specific tables to import.',
+			type: 'string',
+		} );
+		subcommand.option( 'resume', {
+			description: 'Log ID for resuming an existing import.',
+			type: 'string',
+		} );
+		subcommand.option( 'mysqldump', {
+			description: 'Use legacy mysqldump instead of mydumper.',
+			type: 'boolean',
+			default: false,
+		} );
+		subcommand.option( 'debug', {
+			description: 'Enable internal debugging information.',
+			type: 'boolean',
+			default: false,
+		} );
+	},
+	handler,
+};

--- a/lib/commands/stack/util.js
+++ b/lib/commands/stack/util.js
@@ -6,6 +6,13 @@ import Vantage from '../../vantage.js';
 const INDENT = chalk.dim( '→ ' );
 const PROGRESS_WIDTH = 5;
 
+function formatElapsed( ms ) {
+	const s = Math.floor( ms / 1000 );
+	const m = Math.floor( s / 60 );
+	const sec = s % 60;
+	return m > 0 ? `${ m }m ${ sec }s` : `${ sec }s`;
+}
+
 export function getStack(argv) {
 	const { config, stack } = argv;
 
@@ -46,7 +53,8 @@ function renderStatus( status ) {
 	// Write new status bar.
 	const progressChars = Math.floor( status.progress / 100 * PROGRESS_WIDTH );
 	const progress = '░'.repeat( progressChars ) + '⠂'.repeat( Math.max( 0, PROGRESS_WIDTH - progressChars ) );
-	lastStatusLine = `${ status.spinner.frame() } [${ progress }] ${ chalk.yellow( status.step ) }`;
+	const elapsed = status.startTime ? ` ${ chalk.dim( formatElapsed( Date.now() - status.startTime ) ) }` : '';
+	lastStatusLine = `${ status.spinner.frame() } [${ progress }] ${ chalk.yellow( status.step ) }${ elapsed }`;
 	process.stderr.write( lastStatusLine );
 }
 
@@ -62,7 +70,10 @@ export function streamLog(vantage, stack, log, debug) {
 		// Render status at 30fps.
 		let renderLoop = setInterval( () => renderStatus( status ), 1000 / 30 );
 
-		stream.on( 'open', () => status.log.push( chalk.bold.yellow( 'Connected!' ) ) );
+		stream.on( 'open', () => {
+			status.startTime = Date.now();
+			status.log.push( chalk.bold.yellow( 'Connected!' ) );
+		} );
 		stream.on( 'close', () => {
 			// Final render.
 			clearInterval( renderLoop );

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -45,7 +45,7 @@ export default function(url, opts) {
 
 		buf = '';
 
-		stream = got.default.stream(url, reqOpts);
+		stream = got.stream(url, reqOpts);
 
 		onclose = once(() => {
 			if (destroyed) return;

--- a/lib/vantage.js
+++ b/lib/vantage.js
@@ -38,6 +38,7 @@ const OAUTH_PORT = 7277; // ASCII "H" + "M"
 class VantageAPI {
 	constructor( config, region ) {
 		this.config = config;
+		this.debug = false;
 		const sshConfig = config.get( 'ssh' ) || {};
 		this.proxyUser = sshConfig.user || process.env.USER;
 		this.proxyRegion = sshConfig.proxyRegion || region;
@@ -120,7 +121,19 @@ class VantageAPI {
 					},
 				),
 			} );
-			return fetch( absUrl, options );
+			if ( this.debug ) {
+				const method = ( options.method || 'GET' ).toUpperCase();
+				process.stderr.write( chalk.dim( `> ${ method } ${ absUrl }\n` ) );
+				if ( options.body ) {
+					process.stderr.write( chalk.dim( `> Body: ${ options.body }\n` ) );
+				}
+			}
+			return fetch( absUrl, options ).then( resp => {
+				if ( this.debug ) {
+					process.stderr.write( chalk.dim( `< ${ resp.status } ${ resp.statusText }\n` ) );
+				}
+				return resp;
+			} );
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Add `stack import-database` command for importing databases between applications
- Add `--debug` request logging to `vantage.fetch()` for all commands
- Show elapsed time in stream status bar
- Fix `got.stream()` ESM compatibility in `stream.js`

### `import-database` options

- `--from` (required) — source application
- `--replacements` — comma-separated `search=replace` URL replacement pairs
- `--tables` — comma-separated list of specific tables
- `--mysqldump` — use legacy mysqldump instead of mydumper
- `--resume` — resume watching an existing import log
- `--debug` — log HTTP requests/responses

Includes a production safety check that warns and requires confirmation before importing into a production environment.

## Test plan

- [x] `altis-cli stack import-database --help` shows all options
- [x] `altis-cli stack import-database <target> --from <source>` runs import with mydumper
- [x] `altis-cli stack import-database <target> --from <source> --mysqldump` falls back to mysqldump
- [x] `--debug` shows request/response details for all commands
- [x] Elapsed time displays in status bar during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)