### PR TITLE
Publish to npm via trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Publishes to npm when a GitHub Release is published.
-# See RELEASING.md for the full process and required NPM_TOKEN secret.
+# Authenticates to npm as a trusted publisher via OIDC (no token needed).
+# See RELEASING.md for the full process.
 on:
   release:
     types: [published]
@@ -20,6 +21,10 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing via OIDC requires npm >= 11.5.1; Node 20 ships npm 10.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - run: npm ci
 
@@ -42,5 +47,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,17 +47,14 @@ Publishing the release triggers `.github/workflows/release.yml`, which:
 - runs `npm audit` (advisory — does not block the release),
 - publishes to npm with [provenance](https://docs.npmjs.com/generating-provenance-statements).
 
-## One-time setup: the `NPM_TOKEN` secret
+## One-time setup: trusted publishing
 
-Publishing needs an npm access token stored as a repository secret named
-`NPM_TOKEN`:
+Publishing authenticates to npm as a
+[trusted publisher](https://docs.npmjs.com/trusted-publishers) via OIDC — no
+token or repository secret is required.
 
-1. On [npmjs.com](https://www.npmjs.com/) → **Access Tokens** → **Generate New
-   Token** → **Granular Access Token** (recommended) with **Read and write**
-   permission scoped to the `altis-cli` package. Use an **Automation** token so
-   it bypasses 2FA in CI.
-2. In GitHub: **Settings → Secrets and variables → Actions → New repository
-   secret**, name it `NPM_TOKEN`, and paste the token.
+The workflow grants `id-token: write` (for the OIDC exchange) and upgrades npm
+to a version new enough to support trusted publishing.
 
 Provenance additionally requires the repository to be public and the
 `repository` field in `package.json` to be set (both already true).


### PR DESCRIPTION
npm has been connected as a trusted publisher, so auth happens over OIDC and
the NPM_TOKEN repository secret is no longer needed.

Note: also upgrades npm to a version that supports trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)